### PR TITLE
apparently the prompts given to input() go to stderr when python isn't running in tty, maybe this fixture would be helpful generally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- TBD
+- add `jmu_pytest_utils.fixtures.observable_stdin`: without something like this, assignments that wish to test the students' messages prompting the user to provide input would have to specify that they must not use the `input()` function's `prompt` parameter because [when run with output redirection (as in testing with `capsys`)), rather than connected to a tty, the input prompts go to stderr](discuss.python.org/t/builtin-function-input-writes-its-prompt-to-sys-stderr-and-not-to-sys-stdout/12955).
 
 
 ## [1.3.0] - 2025-09-17

--- a/jmu_pytest_utils/fixtures.py
+++ b/jmu_pytest_utils/fixtures.py
@@ -1,0 +1,23 @@
+"""Common test fixtures used in many autograders."""
+
+from pytest import fixture
+
+
+@fixture
+def observable_stdin(monkeypatch, capsys):
+    """
+    Fixture that replaces builtins.input so prompts are printed
+    (capturable by capsys) and test inputs can be fed in.
+    """
+
+    def _make_observable_stdin(responses):
+        responses_iter = iter(responses)
+
+        def fake_input(prompt=""):
+            # mimic real input(): print the prompt
+            print(prompt, end="")
+            return next(responses_iter)
+
+        monkeypatch.setattr("builtins.input", fake_input)
+
+    return _make_observable_stdin


### PR DESCRIPTION
in testing output, as in [test_kiosk](https://github.com/JMU-CS/CS149/commit/ca2b8d72c990e52235423940e2eeda305cada578#diff-7a18da5b10b33a91e23751014c1dc987122395c8425b7fdafec21542489fd343) I needed to read the program's output. I was doing that with capsys, but apparently prompts given to python's `input()` function won't be available in the stdout as captured in this way. We could instruct students to use `print` specifically to output their prompts, but that feels unnecessarily fragile.